### PR TITLE
chore(cardano): enable tagged sets in tx serialization

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -71,7 +71,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/tx": "^5.4.0",
-        "@fivebinaries/coin-selection": "2.2.1",
+        "@fivebinaries/coin-selection": "3.0.0",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",

--- a/packages/connect/src/api/cardano/__fixtures__/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/__fixtures__/cardanoUtils.ts
@@ -145,4 +145,88 @@ export const prepareCertificates = [
             },
         ],
     },
+    {
+        description: 'vote delegation (keyHash)',
+        certificates: [
+            {
+                type: 9,
+                path: "m/1852'/1815'/8'/2/0",
+                dRep: {
+                    type: 0, // keyHash
+                    keyHash: 'hex',
+                },
+            },
+        ],
+        result: [
+            {
+                type: 9,
+                dRep: {
+                    type: 0,
+                    keyHash: 'hex',
+                },
+            },
+        ],
+    },
+    {
+        description: 'vote delegation (scriptHash)',
+        certificates: [
+            {
+                type: 9,
+                path: "m/1852'/1815'/8'/2/0",
+                dRep: {
+                    type: 1, // scriptHash
+                    scriptHash: 'hex',
+                },
+            },
+        ],
+        result: [
+            {
+                type: 9,
+                dRep: {
+                    type: 1,
+                    scriptHash: 'hex',
+                },
+            },
+        ],
+    },
+    {
+        description: 'vote delegation (abstain)',
+        certificates: [
+            {
+                type: 9,
+                path: "m/1852'/1815'/8'/2/0",
+                dRep: {
+                    type: 2, // abstain
+                },
+            },
+        ],
+        result: [
+            {
+                type: 9,
+                dRep: {
+                    type: 2,
+                },
+            },
+        ],
+    },
+    {
+        description: 'vote delegation (no confidence)',
+        certificates: [
+            {
+                type: 9,
+                path: "m/1852'/1815'/8'/2/0",
+                dRep: {
+                    type: 3, // no confidence
+                },
+            },
+        ],
+        result: [
+            {
+                type: 9,
+                dRep: {
+                    type: 3,
+                },
+            },
+        ],
+    },
 ];

--- a/packages/connect/src/api/cardano/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.ts
@@ -47,6 +47,35 @@ export const prepareCertificates = (certs: CardanoCertificate[]) => {
                 convertedCerts.push({
                     type: cert.type,
                 });
+                break;
+            case PROTO.CardanoCertificateType.VOTE_DELEGATION:
+                if (
+                    cert.dRep?.type === PROTO.CardanoDRepType.ABSTAIN ||
+                    cert.dRep?.type === PROTO.CardanoDRepType.NO_CONFIDENCE
+                ) {
+                    convertedCerts.push({
+                        type: cert.type,
+                        dRep: {
+                            type: cert.dRep!.type,
+                        },
+                    });
+                } else if (cert.dRep?.type === PROTO.CardanoDRepType.KEY_HASH) {
+                    convertedCerts.push({
+                        type: cert.type,
+                        dRep: {
+                            type: cert.dRep!.type,
+                            keyHash: cert.dRep.keyHash!,
+                        },
+                    });
+                } else if (cert.dRep?.type === PROTO.CardanoDRepType.SCRIPT_HASH) {
+                    convertedCerts.push({
+                        type: cert.type,
+                        dRep: {
+                            type: cert.dRep!.type,
+                            scriptHash: cert.dRep!.scriptHash!,
+                        },
+                    });
+                }
                 // TODO conway certificates not supported by coin-selection lib yet
                 break;
             // no default

--- a/packages/suite/src/hooks/wallet/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/wallet/useCardanoStaking.ts
@@ -207,6 +207,7 @@ export const useCardanoStaking = (): CardanoStaking => {
                 protocolMagic: getProtocolMagic(account.symbol),
                 networkId: getNetworkId(account.symbol),
                 derivationType: getDerivationType(account.accountType),
+                tagCborSets: true,
                 ttl: txPlan.ttl?.toString(),
                 ...(certificates.length > 0 ? { certificates } : {}),
                 ...(withdrawals.length > 0 ? { withdrawals } : {}),

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -167,6 +167,7 @@ export const signCardanoSendFormTransactionThunk = createThunk<
             inputs: precomposedTransaction.inputs,
             outputs: precomposedTransaction.outputs,
             unsignedTx: precomposedTransaction.unsignedTx,
+            tagCborSets: true,
             testnet: isTestnet(symbol),
             protocolMagic: getProtocolMagic(symbol),
             networkId: getNetworkId(symbol),

--- a/suite-common/wallet-utils/src/__fixtures__/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/cardanoUtils.ts
@@ -624,3 +624,73 @@ export const getDelegationCertificates = [
         ],
     },
 ];
+export const getVotingCertificates = [
+    {
+        description: 'delegating votes to keyHash',
+        stakingPath: 'path',
+        dRep: {
+            type: 0, //keyHash
+            keyHash: 'hex',
+        },
+        result: [
+            {
+                type: 9,
+                path: 'path',
+                dRep: {
+                    type: 0,
+                    keyHash: 'hex',
+                },
+            },
+        ],
+    },
+    {
+        description: 'delegating votes to scriptHash',
+        stakingPath: 'path',
+        dRep: {
+            type: 1, // scriptHash
+            keyHash: 'hex',
+        },
+        result: [
+            {
+                type: 9,
+                path: 'path',
+                dRep: {
+                    type: 1,
+                    scriptHash: 'hex',
+                },
+            },
+        ],
+    },
+    {
+        description: 'delegating votes abstain',
+        stakingPath: 'path',
+        dRep: {
+            type: 2, // abstain
+        },
+        result: [
+            {
+                type: 9,
+                path: 'path',
+                dRep: {
+                    type: 2,
+                },
+            },
+        ],
+    },
+    {
+        description: 'delegating votes no confidence',
+        stakingPath: 'path',
+        dRep: {
+            type: 3, // no confidence
+        },
+        result: [
+            {
+                type: 9,
+                path: 'path',
+                dRep: {
+                    type: 3,
+                },
+            },
+        ],
+    },
+];

--- a/suite-common/wallet-utils/src/__tests__/cardanoUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/cardanoUtils.test.ts
@@ -3,6 +3,7 @@ import { CARDANO, PROTO } from '@trezor/connect';
 import {
     getAddressType,
     getDelegationCertificates,
+    getVotingCertificates,
     getNetworkId,
     getProtocolMagic,
     getShortFingerprint,
@@ -125,6 +126,11 @@ describe('cardano utils', () => {
             expect(
                 getDelegationCertificates(f.stakingPath, f.poolHex, f.shouldRegister),
             ).toMatchObject(f.result);
+        });
+    });
+    fixtures.getVotingCertificates.forEach(f => {
+        it(`getVotingCertificates: ${f.description}`, () => {
+            expect(getVotingCertificates(f.stakingPath, f.dRep)).toMatchObject(f.result);
         });
     });
 });

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -133,6 +133,26 @@ export const getDelegationCertificates = (
     return result;
 };
 
+export const getVotingCertificates = (
+    stakingPath: string,
+    dRep: { keyHash?: string; type: PROTO.CardanoDRepType },
+) => {
+    const result: CardanoCertificate[] = [
+        {
+            type: PROTO.CardanoCertificateType.VOTE_DELEGATION,
+            path: stakingPath,
+            dRep: {
+                keyHash: dRep.type === PROTO.CardanoDRepType.KEY_HASH ? dRep.keyHash : undefined,
+                scriptHash:
+                    dRep.type === PROTO.CardanoDRepType.SCRIPT_HASH ? dRep.keyHash : undefined,
+                type: dRep.type,
+            },
+        },
+    ];
+
+    return result;
+};
+
 export const isPoolOverSaturated = (pool: StakePool, additionalStake?: string) =>
     new BigNumber(pool.live_stake)
         .plus(additionalStake ?? '0')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,17 +2652,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emurgo/cardano-serialization-lib-browser@npm:^11.5.0":
-  version: 11.5.0
-  resolution: "@emurgo/cardano-serialization-lib-browser@npm:11.5.0"
-  checksum: 10/e4d74d20a59ebc20671363fa357c526c10f2f13c9f36fd34b2d269f1c6f3d637be62fe31ea89641cd90a1410aaf5f9613dfe7f3e616cff606ea8f63a7296ecb3
+"@emurgo/cardano-serialization-lib-browser@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "@emurgo/cardano-serialization-lib-browser@npm:13.2.0"
+  checksum: 10/f60f47b7df9e1e783302921d9f225696d09e01b124a75dd8672effae17acdd42779da66a068c923261aabead52ac7aae9426ef13c875f48b5ef7b9d629b8b993
   languageName: node
   linkType: hard
 
-"@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0":
-  version: 11.5.0
-  resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0"
-  checksum: 10/3fff8448001c6d70807ef8e1a80a663ef60381e55bfd26c0f1b644e096895da7298fb991ac86670d4c5aee2e3e417e44ac80ab59080f7af107d8fa89906f9075
+"@emurgo/cardano-serialization-lib-nodejs@npm:13.2.0":
+  version: 13.2.0
+  resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:13.2.0"
+  checksum: 10/b8483dd74ec902da607f0ee00259674ba1794784fafd322948043dd4dfdbddecc81f6546fc98c9a57810639f91110cf76be7755a138a3506af6233954cfe449e
   languageName: node
   linkType: hard
 
@@ -3732,13 +3732,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fivebinaries/coin-selection@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@fivebinaries/coin-selection@npm:2.2.1"
+"@fivebinaries/coin-selection@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@fivebinaries/coin-selection@npm:3.0.0"
   dependencies:
-    "@emurgo/cardano-serialization-lib-browser": "npm:^11.5.0"
-    "@emurgo/cardano-serialization-lib-nodejs": "npm:11.5.0"
-  checksum: 10/3b5a45c9cf978978f96b781a994faf3e09d3cfe88f4f337205385caa1ba11f117d67fc059f09674a2a8064ccdde66bed69a2cb1182686bf83cbb9bdb13365d47
+    "@emurgo/cardano-serialization-lib-browser": "npm:^13.2.0"
+    "@emurgo/cardano-serialization-lib-nodejs": "npm:13.2.0"
+  checksum: 10/06440dcc86a2171a627333d34b9f2192c24f30d7b5d80b0e6d2a791745a01fccffc42f4a84abe5315cb3e52b96fb9cbbbe1696ede8531d18a4bf6a2c2adc2565
   languageName: node
   linkType: hard
 
@@ -11943,7 +11943,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.24.7"
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
-    "@fivebinaries/coin-selection": "npm:2.2.1"
+    "@fivebinaries/coin-selection": "npm:3.0.0"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is the first of two PRs preparing Suite for the upcoming Cardano hard fork. Key updates include:

1. **Transaction Serialization**  
   Post hard fork, all transactions must be serialized using tagged CBOR sets. This feature is already supported by Trezor/Connect (via `tagCborSets` param in `trezorConnect.cardanoSignTransaction`) and is now also available in [@fivebinaries/coinselection](https://github.com/fivebinaries/coin-selection/pull/31).

2. **Staking Rewards Withdrawal**  
   Users withdrawing staking rewards will need to make a governance decision by selecting one of three options:
   - A vote of no confidence
   - Abstaining
   - Delegating to a DRep  

### Changes in This PR
- Upgraded coinselection lib with support for tagged cbor sets and voting certificate
- Utility functions for transforming vote delegation certificates (these will be used in the next PR introducing UI for governance):
  - updated `prepareCertificates` to convert from trezor-connect certificate format into coinselection lib format
  - introduced `getVotingCertificates` for creating voting cert in trezor connect format

Example usage of `getVotingCertificates`:
```ts
 // delegating to DRep
getVotingCertificates(stakingPath, {
  type: PROTO.CardanoDRepType.KEY_HASH,
  keyHash: '<hex>',
}),

  // User does not wish to participate in governance
 getVotingCertificates(stakingPath, {
   type: PROTO.CardanoDRepType.ABSTAIN,
 }),
```

### Next Steps
The next PR will focus on introducing a user interface to allow users to select their preferred governance participation option before proceeding with staking reward withdrawals.
